### PR TITLE
Fix test_parse_arguments_json_without_config exit code

### DIFF
--- a/scripts/test/shtracer_unittest.sh
+++ b/scripts/test/shtracer_unittest.sh
@@ -495,7 +495,8 @@ test_parse_arguments_json_without_config() {
 			parse_arguments "--json" 2>&1
 		)"
 		# Assert ----------
-		assertEquals 1 "$?"
+		# Should exit with EXIT_CONFIG_NOT_FOUND=2 (not EXIT_USAGE=1)
+		assertEquals 2 "$?"
 		echo "$_RETURN_VALUE" | grep -q "Config file required"
 		assertEquals 0 "$?"
 	)


### PR DESCRIPTION
## Summary

Fix incorrect expected exit code in `test_parse_arguments_json_without_config`.

## Problem

The test expected exit code `1` (EXIT_USAGE) but the actual behavior returns `2` (EXIT_CONFIG_NOT_FOUND) when `--json` is used without a config file.

## Solution

Update the test to expect exit code `2` to match the actual behavior defined in shtracer:154:
```bash
error_exit "$EXIT_CONFIG_NOT_FOUND" "parse_arguments" "Config file required"
```

## Test Results

All 72 tests now pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)