### PR TITLE
feat: support hyphen bullets in config parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ test_authenticate_user() {
 ### Configuration File Format
 
 The `config.md` file defines which files to trace and how to organize traceability links. Each section header defines a traceability level (e.g., `## Requirement`, `## Architecture`), and properties specify paths, tag patterns, and filters.
+List markers can use either `*` or `-`.
 
 **Quick Example:**
 

--- a/scripts/main/shtracer_util.sh
+++ b/scripts/main/shtracer_util.sh
@@ -213,7 +213,7 @@ remove_empty_lines() {
 # @return Cleaned lines via stdout (reads stdin)
 # @example echo "* item" | remove_leading_bullets returns "item"
 remove_leading_bullets() {
-	sed 's/^[[:space:]]*\* //'
+	sed 's/^[[:space:]]*[-*] //'
 }
 
 ##

--- a/scripts/test/unit_test/shtracer_config_unittest.sh
+++ b/scripts/test/unit_test/shtracer_config_unittest.sh
@@ -81,6 +81,19 @@ test_remove_comments_strips_bullet_points() {
 	assertEquals "Bullet points should be removed" "0" "$_bullet_count"
 }
 
+test_remove_comments_strips_hyphen_bullet_points() {
+	_test_config="${OUTPUT_DIR%/}/config_hyphen_bullets.md"
+	cat >"$_test_config" <<'EOF'
+## Requirement
+- **PATH**: "./requirements.md"
+  - **TAG FORMAT**: `@REQ[0-9\.]+@`
+EOF
+
+	_result=$(_check_config_remove_comments "$_test_config")
+	_bullet_count=$(echo "$_result" | grep -c '^[[:space:]]*[-*] ' || true)
+	assertEquals "Hyphen and asterisk bullet points should be removed" "0" "$_bullet_count"
+}
+
 test_remove_comments_empty_config() {
 	_result=$(_check_config_remove_comments "./unit_test/testdata/config_empty.md")
 	# Should have only the heading, no fields

--- a/scripts/test/unit_test/shtracer_util_unittest.sh
+++ b/scripts/test/unit_test/shtracer_util_unittest.sh
@@ -294,6 +294,22 @@ test_remove_leading_bullets_spaces() {
 }
 
 ##
+# @brief Test remove_leading_bullets with hyphen marker
+#
+test_remove_leading_bullets_hyphen() {
+	result=$(echo "- item" | remove_leading_bullets)
+	assertEquals "item" "$result"
+}
+
+##
+# @brief Test remove_leading_bullets with spaces and hyphen marker
+#
+test_remove_leading_bullets_hyphen_spaces() {
+	result=$(echo "  - item" | remove_leading_bullets)
+	assertEquals "item" "$result"
+}
+
+##
 # @brief Test extract_from_delimiters with double quotes
 #
 test_extract_from_delimiters_quotes() {


### PR DESCRIPTION
- Accept both '*' and '-' list markers when normalizing config markdown fields.
- Add unit tests for hyphen bullets and document supported markers in README.