### PR TITLE
fix(config): intercept missing trace-target paths before find(1) runs

### DIFF
--- a/scripts/main/shtracer_config.sh
+++ b/scripts/main/shtracer_config.sh
@@ -161,6 +161,47 @@ _check_config_validate() {
 			echo "[check_configfile][warn]: Section \"$_title\" has no TAG FORMAT (tags will not be extracted)" 1>&2
 		fi
 
+		# Validate that the configured PATH actually exists, but only for
+		# sections that will be extracted. Sections without a TAG FORMAT are
+		# intentionally skipped during extraction (mirrors the
+		# `tag_format == ""` skip in _extract_tags_discover_files), so a
+		# missing path there is not an error. Checking here means a
+		# misconfigured PATH is reported by shtracer itself -- readable, with
+		# the section name and the path as written -- instead of leaking
+		# find(1)'s locale-mangled stderr during extraction.
+		if [ -n "$_tag_format" ]; then
+			# PATH is stored quoted in the config table ("..."); unwrap it
+			# the same way _extract_tags_discover_files does.
+			_check_path="$_path"
+			case "$_check_path" in
+				\"*\")
+					_check_path="${_check_path#\"}"
+					_check_path="${_check_path%\"}"
+					;;
+			esac
+
+			# Resolve relative paths against the config.md directory
+			# (CONFIG_DIR), exactly as extraction does via cd "$CONFIG_DIR".
+			case "$_check_path" in
+				/* | [A-Za-z]:[/\\]*)
+					_resolved_path="$_check_path"
+					;;
+				*)
+					_resolved_path="${CONFIG_DIR:-.}/$_check_path"
+					;;
+			esac
+
+			if [ ! -e "$_resolved_path" ]; then
+				# Same exit code the pipeline historically produced for a
+				# missing trace target (no tags -> table build fails), so
+				# the public contract is unchanged; only the message
+				# becomes readable. Literal fallback keeps this correct
+				# even if a caller sources this file without the full
+				# shtracer environment.
+				error_exit "${EXIT_MAKE_TABLE_FAILED:-11}" "check_configfile" "Section \"$_title\": PATH \"$_check_path\" does not exist (resolved: \"$_resolved_path\")"
+			fi
+		fi
+
 		_has_valid_section="$SHTRACER_TRUE"
 	done <"$_CONFIG_TABLE"
 

--- a/scripts/main/shtracer_extract.sh
+++ b/scripts/main/shtracer_extract.sh
@@ -88,9 +88,18 @@ _extract_tags_discover_files() {
 			if (tag_format == "") { next }
 
 			escaped_path = shell_escape(path)
-			cmd = "test -f \""escaped_path"\"; echo $?"; cmd | getline is_file_exist; close(cmd);
-			if (is_file_exist == 0) {
+			cmd = "if [ -f \"" escaped_path "\" ]; then echo F; elif [ -d \"" escaped_path "\" ]; then echo D; else echo X; fi"
+			cmd | getline path_kind; close(cmd);
+			if (path_kind == "F") {
 				print title, path, extension, ignore, brief, tag_format, tag_line_format, tag_title_offset
+			}
+			else if (path_kind == "X") {
+				# Missing path: never run find() here. find writes its
+				# "No such file or directory" message to stderr, which
+				# bypasses `cmd | getline` (stdout only) and leaks to
+				# the terminal locale-mangled. Report it ourselves so
+				# the (possibly non-ASCII) name stays readable.
+				printf "[extract_tags][warn]: Configured PATH does not exist (check config.md): %s\n", path > "/dev/stderr"
 			}
 			else {
 				# for multiple extension filter

--- a/scripts/test/unit_test/shtracer_main_unittest.sh
+++ b/scripts/test/unit_test/shtracer_main_unittest.sh
@@ -623,16 +623,28 @@ test_main_routine_invalid_config_paths() {
 
 		# Act -------------
 		_RETURN="$(main_routine "./unit_test/testdata/config_invalid_paths.md" 2>&1)"
+		_EXIT_CODE=$?
 		IFS=' '
 
 		# Assert ----------
-		# Should output error about no tags found
-		echo "$_RETURN" | grep -q "No tags found"
-		assertEquals 0 "$?"
+		# A configured trace target that does not exist is now reported by
+		# shtracer itself at config-validation time: a readable message
+		# naming the section and the path as written, with the historical
+		# "no tags / table build failed" exit code (contract unchanged).
+		# It must NOT leak find(1)'s locale-mangled "No such file or
+		# directory" stderr (the original motivation for this change:
+		# unreadable garbled paths, especially on Windows/Git Bash).
+		assertEquals "Should fail with the make-table exit code" \
+			"$EXIT_MAKE_TABLE_FAILED" "$_EXIT_CODE"
 
-		# Should output find errors for nonexistent paths
+		echo "$_RETURN" | grep -q "does not exist"
+		assertEquals "Should report the missing PATH readably" 0 "$?"
+
+		echo "$_RETURN" | grep -q "check_configfile"
+		assertEquals "Error should originate from config validation" 0 "$?"
+
 		echo "$_RETURN" | grep -q "No such file or directory"
-		assertEquals 0 "$?"
+		assertNotEquals "Must not leak find's locale-mangled stderr" 0 "$?"
 
 	)
 }


### PR DESCRIPTION
On Windows (Git Bash) and C-locale environments, GNU find octal-escapes non-ASCII bytes in its "No such file or directory" error, making it impossible to identify which configured path was wrong. Because find's error goes to stderr it also bypassed `cmd | getline` in the AWK extraction loop and leaked to the terminal as garbled \NNN sequences.

_check_config_validate now validates PATH existence for every section that carries a TAG FORMAT (mirrors the extraction skip for tag_format="") and calls error_exit with the section name and path as written, exiting with EXIT_MAKE_TABLE_FAILED (11) before find is ever invoked. The public exit-code contract is therefore unchanged.

_extract_tags_discover_files replaces the binary file/non-file test with an explicit F/D/X classification. An X (missing) path emits shtracer's own warning to /dev/stderr and skips — find is never called on it.

UT1.21 (test_main_routine_invalid_config_paths) is updated to assert the new behaviour: exit 11, a "does not exist" message from check_configfile, and no leaked find stderr. Also fixes a latent bug where $? was captured after `IFS=' '` instead of immediately after the command substitution.